### PR TITLE
Removed incorrect info from pagesNumberingWithInk README file

### DIFF
--- a/pagesNumberingWithInk/README.md
+++ b/pagesNumberingWithInk/README.md
@@ -13,8 +13,6 @@ pagesNumberingWithInk(current, numberOfDigits) = 5.
 
 The following numbers will be printed: 1, 2, 3, 4, 5.
 
-There are three independent sequences for systems "stage_1", "stage_2", and "dragon". These sequences are [1, 2], [10, 12], and [11, 111], respectively. The elements are in strictly increasing order for all three.
-
 -   For current = 21 and numberOfDigits = 5, the output should be
 pagesNumberingWithInk(current, numberOfDigits) = 22.
 

--- a/pagesNumberingWithInk/pagesNumberingWithInk.ts
+++ b/pagesNumberingWithInk/pagesNumberingWithInk.ts
@@ -1,3 +1,7 @@
 function pagesNumberingWithInk(current: number, numberOfDigits: number): number {
 
 }
+
+console.log(pagesNumberingWithInk(1, 5));
+console.log(pagesNumberingWithInk(21, 5));
+console.log(pagesNumberingWithInk(8, 4));


### PR DESCRIPTION
Seems like there was information from another algorithm in the README file.